### PR TITLE
Version 3.0.0-beta.5

### DIFF
--- a/de.schmidhuberj.tubefeeder.json
+++ b/de.schmidhuberj.tubefeeder.json
@@ -33,7 +33,7 @@
         "--filesystem=xdg-data/tubefeeder:create",
         "--filesystem=xdg-download",
         "--talk-name=org.freedesktop.Flatpak",
-        "--own-name=org.mpris.MediaPlayer2.tubefeeder",
+        "--own-name=org.mpris.MediaPlayer2.tubefeeder.*",
         "--env=CLAPPER_ENHANCERS_PATH=/app/extensions/clapper/enhancers/plugins",
         "--env=PYTHONPATH=/app/extensions/clapper/enhancers/python/site-packages"
     ],
@@ -58,8 +58,8 @@
                 {
                     "type": "archive",
                     "archive-type": "tar-xz",
-                    "url": "https://gitlab.com/api/v4/projects/48404603/packages/generic/pipeline/3.0.0-beta.4/tubefeeder-3.0.0-beta.4.tar.xz",
-                    "sha256": "cd33cf71e72db1da953653356e5f176aad311b2e606c1362c9016450c8894137"
+                    "url": "https://gitlab.com/api/v4/projects/48404603/packages/generic/pipeline/3.0.0-beta.5/tubefeeder-3.0.0-beta.5.tar.xz",
+                    "sha256": "960ecdf572ecdfd2dcfb84534c25f9c1162f5bbecaf5ad3111676cde199787ed"
                 }
             ]
         }


### PR DESCRIPTION
This requires a minor change to the MPRIS permission, to not only own org.mpris.MediaPlayer2.tubefeeder itself but also the entire prefix. This is required as Pipeline can now be used to navigate between multiple videos where old videos stay in the background; all videos (in the background or foreground) will still need to be displayed in MPRIS. With only one name owned, this would create conflicts between the video pages. See also https://gitlab.com/schmiddi-on-mobile/pipeline/-/merge_requests/314.