### PR TITLE
Version 3.0.0

### DIFF
--- a/de.schmidhuberj.tubefeeder.json
+++ b/de.schmidhuberj.tubefeeder.json
@@ -1,7 +1,7 @@
 {
     "app-id": "de.schmidhuberj.tubefeeder",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -33,7 +33,7 @@
         "--filesystem=xdg-data/tubefeeder:create",
         "--filesystem=xdg-download",
         "--talk-name=org.freedesktop.Flatpak",
-        "--own-name=org.mpris.MediaPlayer2.tubefeeder",
+        "--own-name=org.mpris.MediaPlayer2.tubefeeder.*",
         "--env=CLAPPER_ENHANCERS_PATH=/app/extensions/clapper/enhancers/plugins",
         "--env=PYTHONPATH=/app/extensions/clapper/enhancers/python/site-packages"
     ],
@@ -58,8 +58,8 @@
                 {
                     "type": "archive",
                     "archive-type": "tar-xz",
-                    "url": "https://gitlab.com/api/v4/projects/48404603/packages/generic/pipeline/2.6.1/tubefeeder-2.6.1.tar.xz",
-                    "sha256": "6b3736ff4325d33859c4bd2e6770bf7060429a939e6bb8a03db231831e60085a"
+                    "url": "https://gitlab.com/api/v4/projects/48404603/packages/generic/pipeline/3.0.0/tubefeeder-3.0.0.tar.xz",
+                    "sha256": "cc1091889f63b27c3f1afc4edd27e378b269a6a7328585886d4b4bd009988dc4"
                 }
             ]
         }


### PR DESCRIPTION
This requires a minor change to the MPRIS permission, to not only own org.mpris.MediaPlayer2.tubefeeder itself but also the entire prefix. This is required as Pipeline can now be used to navigate between multiple videos where old videos stay in the background; all videos (in the background or foreground) will still need to be displayed in MPRIS. With only one name owned, this would create conflicts between the video pages. See also https://gitlab.com/schmiddi-on-mobile/pipeline/-/merge_requests/314.

This closes #49.