### PR TITLE
Pipewire support

### DIFF
--- a/de.schmidhuberj.tubefeeder.json
+++ b/de.schmidhuberj.tubefeeder.json
@@ -23,6 +23,7 @@
         "--socket=pulseaudio",
         "--device=all",
         "--share=network",
+        "--filesystem=xdg-run/pipewire-0:ro",
         "--filesystem=xdg-data/tubefeeder:create",
         "--filesystem=xdg-videos/Pipeline:create",
         "--own-name=org.mpris.MediaPlayer2.tubefeeder.*",


### PR DESCRIPTION
Add the permission for Pipeline to use Pipewire for audio during video playback.