### PR TITLE
Update yt-dlp

### DIFF
--- a/de.schmidhuberj.tubefeeder.json
+++ b/de.schmidhuberj.tubefeeder.json
@@ -28,8 +28,8 @@
         "--filesystem=xdg-videos/Pipeline:create",
         "--own-name=org.mpris.MediaPlayer2.tubefeeder.*",
         "--env=CLAPPER_ENHANCERS_PATH=/app/extensions/clapper/enhancers/plugins",
-        "--env=PYTHONPATH=/app/extensions/clapper/enhancers/python/site-packages",
-        "--env=PATH=/app/bin:/usr/bin:/app/extensions/clapper/enhancers/python/site-packages/bin"
+        "--env=PYTHONPATH=/app/python/site-packages",
+        "--env=PATH=/app/bin:/usr/bin:/app/python/site-packages/bin"
     ],
     "build-options": {
         "append-path": "/usr/lib/sdk/rust-stable/bin",
@@ -45,6 +45,7 @@
     "modules": [
         "lib/libpeas.json",
         "lib/clapper.json",
+        "lib/python-modules.json",
         {
             "name": "tubefeeder",
             "buildsystem": "meson",

--- a/lib/python-modules.json
+++ b/lib/python-modules.json
@@ -1,0 +1,34 @@
+{
+    "name": "python-modules",
+    "buildsystem": "simple",
+    "build-options": {
+        "env": {
+            "PIP_TARGET": "/app/python/site-packages"
+        }
+    },
+    "build-commands": [
+        "pip3 install -v --root-user-action=ignore --no-deps *.whl"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/e3/bd/520769863744b669440a924271a6159ddd82ad5ae26b4ac4d4b69e9f8d44/yt_dlp_ejs-0.8.0-py3-none-any.whl",
+            "sha256": "79300e5fca7f937a1eeede11f0456862c1b41107ce1d726871e0207424f4bdb4",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "yt-dlp-ejs",
+                "packagetype": "bdist_wheel"
+            }
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/f9/8a/cd4c9b02c10c563adfe78118310129641900e1cd6de888cfae2452072696/yt_dlp-2026.7.4-py3-none-any.whl",
+            "sha256": "f11f2b11d5a8ac4059f9bdf29fa4407dc7c6bb00c5097e95ca22a7a9db518266",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "yt-dlp",
+                "packagetype": "bdist_wheel"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This fixes low playback and download resolution. A proper fix would be an updated yt-dlp with Clapper-Enhancers, but that currently cannot be updated due to Clapper using an outdated runtime and therefore building it is rejected by Flathub.